### PR TITLE
Sensible app ID

### DIFF
--- a/class/connector.js
+++ b/class/connector.js
@@ -48,7 +48,7 @@ class Connector {
 			url: YTMDesktopUrl + "/api/v1/auth/requestcode",
 			type: "POST",
 			data: JSON.stringify({
-				"appId": "42069",
+				"appId": "topik-obs-widget",
 				"appName": "Youtube Music OBS Widget (by Topik)",
 				"appVersion": "2.0.0"
 			}),

--- a/class/connector.js
+++ b/class/connector.js
@@ -23,7 +23,7 @@ class Connector {
 			url: YTMDesktopUrl + "/api/v1/auth/request",
 			type: "POST",
 			data: JSON.stringify({
-				"appId": "42069",
+				"appId": "topik-obs-widget",
 				"code": that.authCode
 			}),
 			contentType: "application/json; charset=utf-8",


### PR DESCRIPTION
https://github.com/ytmdesktop/ytmdesktop/wiki/v2-%E2%80%90-Companion-Server-API-v1#:~:text=appId%3A%20Must%20be%20all%20lowercase%20with%20only%20alphanumeric%20characters%2C%20no%20spaces%20and%20between%202%20and%2032%20characters

Change the App ID to be more sensible compared to the 42069 which is currently used 😏