### PR TITLE
fix: track not switching after ad

### DIFF
--- a/class/player.js
+++ b/class/player.js
@@ -12,29 +12,30 @@ class Player {
 			this.isPlaying = true;
 			$("body").removeClass("isOffline");
 			$("body").removeClass("paused");
-			if (this.lastUpdateData.hasOwnProperty("track") && JSON.stringify(this.lastUpdateData.track) === JSON.stringify(playerInfo.track)) {
-				this.updateTrackTime(playerInfo);
-			} else {
-				if (playerInfo.hasOwnProperty("track") === false) {
-					return;
-				}
-				if (playerInfo.track.hasOwnProperty("cover")) {
-					let img = new Image();
-					let that = this;
-					img.onload = function () {
-						that.updateTrackInfo(playerInfo);
-					};
-					img.src = this.getAlbumArt(playerInfo.track.cover, 420, 420);
-				} else {
-					this.updateTrackInfo(playerInfo);
-				}
-
-			}
 		} else {
 			this.isPlaying = false;
 			$("body").addClass("isOffline");
 			$("body").addClass("paused");
 		}
+
+		if (this.lastUpdateData.hasOwnProperty("track") && JSON.stringify(this.lastUpdateData.track) === JSON.stringify(playerInfo.track)) {
+			this.updateTrackTime(playerInfo);
+		} else {
+			if (playerInfo.hasOwnProperty("track") === false) {
+				return;
+			}
+			if (playerInfo.track.hasOwnProperty("cover")) {
+				let img = new Image();
+				let that = this;
+				img.onload = function () {
+					that.updateTrackInfo(playerInfo);
+				};
+				img.src = this.getAlbumArt(playerInfo.track.cover, 420, 420);
+			} else {
+				this.updateTrackInfo(playerInfo);
+			}
+		}
+
 		this.lastUpdateData = playerInfo;
 	}
 


### PR DESCRIPTION
Currently, if an ad plays right after a track ends, the next track is loaded with a false `playState`. This means the track does not get updated, however it still gets saved in `this.lastUpdateData`, meaning you must change tracks to update the widget.

This PR simply moves the track updating logic outside the `playState` check, to update the information regardless.

This also fixes an edge case, where if you open the widget, but resume an already paused track instead of playing a new one, the track information would not be updated.